### PR TITLE
Allow to skip integerisation

### DIFF
--- a/pling/dcj_snakemake/Snakefile
+++ b/pling/dcj_snakemake/Snakefile
@@ -21,6 +21,13 @@ def get_timelimit(timelimit):
     else:
         return f"--timelimit {timelimit}"
 
+def get_unimog():
+    if config.get("unimog", False):
+        unimog = config["unimog"]
+        return f"--unimog {unimog}"
+    else:
+        return ""
+
 rule all:
     input:
         dcj_graph_outdir = f"{OUTPUTPATH}/dcj_thresh_{dcj_threshold}_graph"
@@ -39,7 +46,8 @@ if config["ilp_solver"] == "GLPK":
             batch=lambda wildcards: wildcards.batch,
             timelimit=get_timelimit(config["timelimit"]),
             snakefile_dir=os.path.dirname(sys.argv[sys.argv.index("--snakefile")+1]),
-            pling_root_dir = get_pling_root_dir()
+            pling_root_dir = get_pling_root_dir(),
+            unimog = get_unimog()
         threads: 1 #no multithreading available for GLPK
         resources:
             mem_mb = lambda wildcards, attempt: attempt * config["ilp_mem"]
@@ -56,7 +64,8 @@ if config["ilp_solver"] == "GLPK":
                         --integerisation {params.integerisation} \
                         {params.timelimit} \
                         --threads {threads} \
-                        --snakefile_dir {params.snakefile_dir}
+                        --snakefile_dir {params.snakefile_dir} \
+                        {params.unimog}
                 """
 
 elif config["ilp_solver"] == "gurobi":
@@ -72,7 +81,8 @@ elif config["ilp_solver"] == "gurobi":
             communitypath=f"{COMMUNITIES}/objects/communities.txt",
             batch=lambda wildcards: wildcards.batch,
             timelimit=get_timelimit(config["timelimit"]),
-            pling_root_dir = get_pling_root_dir()
+            pling_root_dir = get_pling_root_dir(),
+            unimog = get_unimog()
         threads: config["ilp_threads"]
         resources:
             mem_mb = lambda wildcards, attempt: attempt * config["ilp_mem"]
@@ -89,6 +99,7 @@ elif config["ilp_solver"] == "gurobi":
                         --integerisation {params.integerisation} \
                         {params.timelimit} \
                         --threads {threads} \
+                        {params.unimog}
                 """
 else:
     raise Exception("Not a valid ILP solver!")

--- a/pling/dcj_snakemake/glpk_and_ding.py
+++ b/pling/dcj_snakemake/glpk_and_ding.py
@@ -39,7 +39,7 @@ def dcj_dist(unimog, solution, genome1, genome2):
         raise e
     return dist
 
-def batchwise_ding(pairs, containment_distance, containments, integerisation, outputpath, batch, timelimit, snakefile_dir, plasmid_to_community):
+def batchwise_ding(pairs, containment_distance, containments, integerisation, outputpath, batch, timelimit, snakefile_dir, plasmid_to_community, unimog_path=None):
     dists = []
     for pair in pairs:
         genome1 = pair[0]
@@ -48,7 +48,7 @@ def batchwise_ding(pairs, containment_distance, containments, integerisation, ou
         solution = f"ding/solutions/{genome1}~{genome2}.sol"
         entry1, entry2 = get_entries(integerisation, genome1, genome2)
         if containments[(genome1,genome2)]<=containment_distance:
-            unimog = get_unimog(outputpath, integerisation, plasmid_to_community, batch, genome1, genome2)
+            unimog = get_unimog(outputpath, integerisation, plasmid_to_community, batch, genome1, genome2, unimog_path)
             unimog_to_ilp(unimog, lp, entry1, entry2)
             ilp_GLPK(lp, solution, snakefile_dir, timelimit)
             dist = dcj_dist(unimog, solution, entry1, entry2)
@@ -71,6 +71,7 @@ def main():
     parser.add_argument("--threads")
     parser.add_argument("--timelimit")
     parser.add_argument("--snakefile_dir", required=True)
+    parser.add_argument("--unimog")
 
     # Parse the arguments
     args = parser.parse_args()
@@ -92,7 +93,10 @@ def main():
     else:
         plasmid_to_community=None
 
-    batchwise_ding(pairs, float(args.containment_distance), containments, args.integerisation, args.outputpath, args.batch, timelimit, args.snakefile_dir, plasmid_to_community)
+    if args.integerisation=="skip":
+        batchwise_ding(pairs, float(args.containment_distance), containments, args.integerisation, args.outputpath, args.batch, timelimit, args.snakefile_dir, plasmid_to_community, args.unimog)
+    else:
+        batchwise_ding(pairs, float(args.containment_distance), containments, args.integerisation, args.outputpath, args.batch, timelimit, args.snakefile_dir, plasmid_to_community)
 
 if __name__ == "__main__":
     main()

--- a/pling/dcj_snakemake/gurobi_and_ding.py
+++ b/pling/dcj_snakemake/gurobi_and_ding.py
@@ -115,14 +115,14 @@ def compute_DCJ(unimog, entry1, entry2, timelimit, threads):
         raise e
     return int(round(dist))
 
-def batchwise_ding(pairs, containment_distance, containments, integerisation, outputpath, batch, timelimit, threads, plasmid_to_community):
+def batchwise_ding(pairs, containment_distance, containments, integerisation, outputpath, batch, timelimit, threads, plasmid_to_community,unimog_path=None):
     dists = []
     for pair in pairs:
         genome1 = pair[0]
         genome2 = pair[1]
         entry1, entry2 = get_entries(integerisation, genome1, genome2)
         if containments[(genome1,genome2)]<=containment_distance:
-            unimog = get_unimog(outputpath, integerisation, plasmid_to_community, batch, genome1, genome2)
+            unimog = get_unimog(outputpath, integerisation, plasmid_to_community, batch, genome1, genome2, unimog_path)
             dist = compute_DCJ(unimog, entry1, entry2, timelimit, threads)
             dists.append(f"{genome1}\t{genome2}\t{dist}\n")
     with open(f"{outputpath}/tmp_files/dists_batchwise/batch_{batch}_dcj.tsv", "w") as f:
@@ -142,6 +142,7 @@ def main():
     parser.add_argument("--integerisation", required=True, type=str)
     parser.add_argument("--threads", required=True, type=int)
     parser.add_argument("--timelimit")
+    parser.add_argument("--unimog")
 
     # Parse the arguments
     args = parser.parse_args()
@@ -154,7 +155,10 @@ def main():
     else:
         plasmid_to_community=None
 
-    batchwise_ding(pairs, float(args.containment_distance), containments, args.integerisation, args.outputpath, args.batch, args.timelimit, args.threads, plasmid_to_community)
+    if args.integerisation=="skip":
+        batchwise_ding(pairs, float(args.containment_distance), containments, args.integerisation, args.outputpath, args.batch, args.timelimit, args.threads, plasmid_to_community, args.unimog)
+    else:
+        batchwise_ding(pairs, float(args.containment_distance), containments, args.integerisation, args.outputpath, args.batch, args.timelimit, args.threads, plasmid_to_community)
 
 if __name__ == "__main__":
     main()

--- a/pling/dcj_snakemake/shared_functions.py
+++ b/pling/dcj_snakemake/shared_functions.py
@@ -16,17 +16,21 @@ def get_containment_distances_for_batch(containment_tsv):
             containments[(plasmid_1,plasmid_2)] = containment
     return containments
 
-def get_unimog(outputpath, integerisation, plasmid_to_community, batch, genome1, genome2):
+def get_unimog(outputpath, integerisation, plasmid_to_community, batch, genome1, genome2, unimog_path=None):
     unimog = ""
     if integerisation == "align":
         unimog = f"{outputpath}/unimogs/batch_{batch}_align.unimog"
     elif integerisation == "anno":
         community = plasmid_to_community[genome1]
         unimog = f"{outputpath}/unimogs/relabelled/blocks/{community}_blocks.unimog"
+    elif integerisation == "skip":
+        unimog=unimog_path
     return unimog
 
 def get_entries(integerisation, genome_1, genome_2):
     if integerisation == "align":
         return f"{genome_1}~{genome_2}:{genome_1}", f"{genome_1}~{genome_2}:{genome_2}"
     elif integerisation == "anno":
+        return genome_1, genome_2
+    elif integerisation == "skip":
         return genome_1, genome_2


### PR DESCRIPTION
Containment network is still calculated from nucmer, like in anno workflow, but then DCJ is calculated from a provided unimog file (one entry per genome, i.e. not pairwise defined). Solves #63 